### PR TITLE
Added working demonstration source code

### DIFF
--- a/doc/cfgdemo/.gitignore
+++ b/doc/cfgdemo/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/doc/cfgdemo/Cargo.toml
+++ b/doc/cfgdemo/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cfgdemo"
+version = "0.1.0"
+authors = ["Geert Stappers <stappers@stappers.it>"]
+edition = "2018"
+
+[dependencies]
+quire = "0.4.1"
+serde = "1.0.97"
+serde_derive = "1.0.97"

--- a/doc/cfgdemo/config.yaml
+++ b/doc/cfgdemo/config.yaml
@@ -1,0 +1,8 @@
+#
+---
+item1:  foo
+# comment
+item2:  bar
+_item3:  underscore used to comment out a keyword
+...
+# l l

--- a/doc/cfgdemo/src/main.rs
+++ b/doc/cfgdemo/src/main.rs
@@ -1,0 +1,30 @@
+extern crate quire;
+#[macro_use] extern crate serde_derive;
+use quire::{parse_config, Options};
+use quire::validate::{Structure, Scalar};
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+struct Config {
+    item1: String,
+    item2: Option<String>,
+}
+
+fn validator() -> Structure<'static> {
+    Structure::new()
+    .member("item1", Scalar::new())
+    .member("item2", Scalar::new().optional())
+}
+
+fn work(cfg: &Config) {
+    println!("item1 is {}.", cfg.item1);
+    //intln!("item2 is {}.", cfg.item2);
+    // hey, this is just demonstration code ...
+}
+
+fn main() {
+    let cfg: Config;
+    cfg = parse_config("config.yaml", &validator(), &Options::default())
+        .expect("valid config");
+    work(&cfg)
+}


### PR DESCRIPTION
Under doc/ is now cfgdemo/ which has a working example.
Including a `config.yaml`.