### PR TITLE
Working example for lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,26 +4,35 @@
 //!
 //! ```rust,ignore  # for some reason this crashes compiler
 //! extern crate quire;
-//! #[macor_use] extern crate serde_derive;
+//! #[macro_use] extern crate serde_derive;
 //! use quire::{parse_config, Options};
 //! use quire::validate::{Structure, Scalar};
 //!
 //! #[derive(Deserialize)]
+//! #[allow(dead_code)]
 //! struct Config {
 //!     item1: String,
 //!     item2: Option<String>,
 //! }
 //!
-//! fn validator<'static>() -> Structure<'static> {
+//! fn validator() -> Structure<'static> {
 //!     Structure::new()
 //!     .member("item1", Scalar::new())
 //!     .member("item2", Scalar::new().optional())
 //! }
 //!
-//! let cfg: Config;
-//! cfg = parse_config("config.yaml", &validator(), &Options::default())
-//!       .expect("valid config");
+//! fn work(cfg: &Config) {
+//!     println!("item1 is {}.", cfg.item1);
+//!     //intln!("item2 is {}.", cfg.item2);
+//!     // hey, this is just demonstration code ...
+//! }
 //!
+//! fn main() {
+//!     let cfg: Config;
+//!     cfg = parse_config("config.yaml", &validator(), &Options::default())
+//!         .expect("valid config");
+//!     work(&cfg)
+//! }
 //! ```
 //!
 #![warn(missing_debug_implementations)]


### PR DESCRIPTION
There is now a `main()` which makes it a working program.
Function `work(cfg)` uses the configuration from the YAML file.
Allow that not all fields of the configuration structure are used.
Fixed a typo  ( `macor` versus `macro` )